### PR TITLE
bug fix: remove NaN on page load

### DIFF
--- a/app/cinemas/components/CinemaCard.tsx
+++ b/app/cinemas/components/CinemaCard.tsx
@@ -26,7 +26,7 @@ const CinemaCard: FC<CinemaCardProps> = ({ cinema, distance }) => {
       <Link href={`/cinemas/${cinema.cinemaName}`}>
         <div className="p-5 lg:p-10 mt-5 pb-15 absolute top-0 left-0 text-white">
           <h2 className="text-2xl font-bold">{cinema.cinemaName}</h2>
-          <h3 className="mb-10">{distance ? distance.distance : ""}</h3>
+          <h3 className="mb-10">{distance === "Nankm" ? distance.distance : ""}</h3>
           <h3 className="mb-10">{cinema.area}</h3>
           <p className="mb-10">{cinema.about}</p>
           <CinemaFeaturesList cinema={cinema} />


### PR DESCRIPTION
Cinema browsing page now shows empty string until user enters a postcode